### PR TITLE
Test Harness support for --physical flag

### DIFF
--- a/sim/SPI_v3/components/SPITestHarness.py
+++ b/sim/SPI_v3/components/SPITestHarness.py
@@ -12,7 +12,7 @@ from pymtl3 import *
 from pymtl3.stdlib.test_utils import config_model_with_cmdline_opts
 
 from math import ceil
-import copy
+import copy, sys
 from spidriver import SPIDriver
 
 #=========================================================================
@@ -34,7 +34,7 @@ class SPITestHarness( object ):
   def __init__( s, DESIGN, num_components, spi_bits, cmdline_opts, trace=True ):
  
     s.dut = DESIGN
-    s.is_phy_test = False  # Change this switch to True if you want to use the Physical Test Harness and the SPIDriver
+    s.is_phy_test = sys._is_physical  # Use the --physical flag in pytest if you want to use the Physical Test Harness and the SPIDriver
     s.dut = config_model_with_cmdline_opts( s.dut, cmdline_opts, [] )
     s.dut.apply(DefaultPassGroup(linetrace=True)) #commented out for chip-sim
     # from pymtl3.passes.mamba import Mamba2020

--- a/sim/conftest.py
+++ b/sim/conftest.py
@@ -16,6 +16,9 @@ def pytest_addoption(parser):
 
   parser.addoption( "--vrtl", action="store_true",
                     help="use VRTL implementations" )
+  
+  parser.addoption( "--physical", action="store_true",
+                    help="Use tests on a physical chip" )
 
 #-------------------------------------------------------------------------
 # Handle other command line options
@@ -25,6 +28,7 @@ def pytest_configure(config):
   import sys
   sys._called_from_test   = True
   sys._pymtl_rtl_override = False
+  sys._is_physical        = config.option.physical
   if config.option.prtl:
     sys._pymtl_rtl_override = 'pymtl'
   elif config.option.vrtl:
@@ -34,6 +38,7 @@ def pytest_unconfigure(config):
   import sys
   del sys._called_from_test
   del sys._pymtl_rtl_override
+  del sys._is_physical
 
 #-------------------------------------------------------------------------
 # fix_randseed


### PR DESCRIPTION
@ki5953 @jbrzozo24 Changes to allow command line switching between RTL and hardware testing. Users can specify the `--physical` flag in their `pytest` command to test using the SPI Driver

(I'd also put it in the PDF documentation, but can't change it :) )